### PR TITLE
Check IDs uniqueness

### DIFF
--- a/src/pages/HistoryRestorer/api/validate.ts
+++ b/src/pages/HistoryRestorer/api/validate.ts
@@ -12,6 +12,24 @@ export async function validate(items: Item[]): Promise<ValidationResult[]> {
   if (items.some((item) => !item.fromId || !item.toId)) {
     throw new Error('Some fields are blank');
   }
+  const fromIdSet = new Set();
+  for (const item of items) {
+    if (fromIdSet.has(item.fromId)) {
+      throw new Error(
+        `${MAP[item.type]} ${item.fromId} in Deleted Features is duplicated`,
+      );
+    }
+    fromIdSet.add(item.fromId);
+  }
+  const toIdSet = new Set();
+  for (const item of items) {
+    if (toIdSet.has(item.toId)) {
+      throw new Error(
+        `${MAP[item.type]} ${item.toId} in New Features is duplicated`,
+      );
+    }
+    toIdSet.add(item.toId);
+  }
 
   const toFetch: Record<LongNWR, (string | number)[]> = {
     node: items.filter((item) => item.type === 'n').map((item) => item.toId!),


### PR DESCRIPTION
I tried to use your tool and accidentally duplicated object IDs and got a strange error:

<img width="658" height="543" src="https://github.com/user-attachments/assets/25e10643-8f28-49b8-a6ab-724fdb0371d0" />

I propose adding a check for object uniqueness. I'm deliberately ignoring `item.type`, as it's highly unlikely that someone would restore nodes/lines/relations with the same ID in a single changeset. However, this would provide additional confidence that the user selected the correct object type.