### PR TITLE
Remember last OSM type

### DIFF
--- a/src/pages/HistoryRestorer/HistoryRestorer.tsx
+++ b/src/pages/HistoryRestorer/HistoryRestorer.tsx
@@ -5,7 +5,8 @@ import { save, validate } from './api';
 import type { Item, NWR, ValidationResult } from './util';
 import classes from './HistoryRestorer.module.css';
 
-const NEW_FEATURE = (): Item => ({ type: 'n' });
+let lastFeatureType: NWR = 'n';
+const NEW_FEATURE = (): Item => ({ type: lastFeatureType });
 
 const SelectNWR: React.FC<{ value: NWR; onChange(newValue: NWR): void }> = ({
   value,
@@ -15,7 +16,10 @@ const SelectNWR: React.FC<{ value: NWR; onChange(newValue: NWR): void }> = ({
     <select
       className={classes.smallInput}
       value={value}
-      onChange={(event) => onChange(event.target.value as NWR)}
+      onChange={(event) => {
+        lastFeatureType = event.target.value as NWR;
+        onChange(lastFeatureType);
+      }}
     >
       <option value="n">Node</option>
       <option value="w">Way</option>


### PR DESCRIPTION
I wanted to restore histories to a few buildings, and I was getting a little tired of constantly changing the object type. This PR adds a memory for the object type you last changed.

https://github.com/user-attachments/assets/ed3c92f2-90be-4848-9324-faa100fde49f

